### PR TITLE
OTP：consider multiple modules；initialize otp_info；add reading OTP lotid CRC info

### DIFF
--- a/driver-avalon8.c
+++ b/driver-avalon8.c
@@ -1534,6 +1534,11 @@ static void detect_modules(struct cgpu_info *avalon8)
 				info->set_asic_otp[i][j] = 0; /* default asic: 0 */
 			else
 				info->set_asic_otp[i][j] = opt_avalon8_asic_otp;    
+           
+            for(k = 0; k < 11; k++) {
+                if ((info->otp_info[i][j][k] < 32) || (info->otp_info[i][j][k] > 126))
+                    info->otp_info[i][j][k] = '0';
+            }
         }
 
 		info->freq_mode[i] = AVA8_FREQ_INIT_MODE;

--- a/driver-avalon8.c
+++ b/driver-avalon8.c
@@ -699,23 +699,23 @@ static int decode_pkg(struct cgpu_info *avalon8, struct avalon8_ret *ar, int mod
 		/* the reading step on MM side, 0:byte 3-0, 1:byte 7-4, 2:byte 11-8 */
 		switch (ar->data[15]) {
 		case 0:
-			memcpy(info->otp_info[miner_id], ar->data, 4);
+			memcpy(info->otp_info[modular_id][miner_id], ar->data, 4);
 			break;
 		case 1:
-			memcpy(info->otp_info[miner_id] + 4, ar->data + 4, 4);
+			memcpy(info->otp_info[modular_id][miner_id] + 4, ar->data + 4, 4);
 			break;
 		case 2:
-			memcpy(info->otp_info[miner_id] + 8, ar->data + 8, 4);
+			memcpy(info->otp_info[modular_id][miner_id] + 8, ar->data + 8, 4);
 			break;
 		default:
 			break;
 		}
-		memcpy(info->otp_info[miner_id] + 15, ar->data + 15, 4);
+		memcpy(info->otp_info[modular_id][miner_id] + 15, ar->data + 15, 4);
 
 		/* check for invisible charactor */
 		for(i = 0; i < 11; i++) {
-			if ((info->otp_info[miner_id][i] < 32) || (info->otp_info[miner_id][i] > 126))
-				info->otp_info[miner_id][i] = '0';
+			if ((info->otp_info[modular_id][miner_id][i] < 32) || (info->otp_info[modular_id][miner_id][i] > 126))
+				info->otp_info[modular_id][miner_id][i] = '0';
 		}
 		break;
 	case AVA8_P_STATUS_VOLT:
@@ -1533,8 +1533,8 @@ static void detect_modules(struct cgpu_info *avalon8)
 			if (AVA8_INVALID_ASIC_OTP == opt_avalon8_asic_otp)
 				info->set_asic_otp[i][j] = 0; /* default asic: 0 */
 			else
-				info->set_asic_otp[i][j] = opt_avalon8_asic_otp;
-		}
+				info->set_asic_otp[i][j] = opt_avalon8_asic_otp;    
+        }
 
 		info->freq_mode[i] = AVA8_FREQ_INIT_MODE;
 		memset(info->get_pll[i], 0, sizeof(uint32_t) * info->miner_count[i] * AVA8_DEFAULT_PLL_CNT);
@@ -2263,24 +2263,24 @@ static struct api_data *avalon8_api_stats(struct cgpu_info *avalon8)
 		if (opt_debug) {
 			for (k = 0; k < AVA8_DEFAULT_MINER_CNT; k++) {
 				sprintf(buf, " LotID%d_ASIC%d[%c%c%c%c%c%c%c%c%c]", k,
-				info->otp_info[k][16],
-				info->otp_info[k][0],
-				info->otp_info[k][1],
-				info->otp_info[k][2],
-				info->otp_info[k][3],
-				info->otp_info[k][4],
-				info->otp_info[k][5],
-				info->otp_info[k][6],
-				info->otp_info[k][7],
-				info->otp_info[k][8]);
+				info->otp_info[i][k][16],
+				info->otp_info[i][k][0],
+				info->otp_info[i][k][1],
+				info->otp_info[i][k][2],
+				info->otp_info[i][k][3],
+				info->otp_info[i][k][4],
+				info->otp_info[i][k][5],
+				info->otp_info[i][k][6],
+				info->otp_info[i][k][7],
+				info->otp_info[i][k][8]);
 				strcat(statbuf, buf);
 			}
 
 			for (k = 0; k < AVA8_DEFAULT_MINER_CNT; k++) {
 				sprintf(buf, " WaferID%d_ASIC%d[%c%c]", k,
-				info->otp_info[k][16],
-				info->otp_info[k][9],
-				info->otp_info[k][10]);
+				info->otp_info[i][k][16],
+				info->otp_info[i][k][9],
+				info->otp_info[i][k][10]);
 				strcat(statbuf, buf);
 			}
 		}

--- a/driver-avalon8.h
+++ b/driver-avalon8.h
@@ -205,6 +205,12 @@
 #define AVA8_MM841_VOUT_ADC_RATIO	(3.3 / 4095.0 * 63.0 / 20.0 * 10000.0 * 100.0)
 #define AVA8_MM851_VOUT_ADC_RATIO	(3.3 / 4095.0 * 72.3 / 20.0 * 10000.0 * 100.0)
 
+#define AVA8_OTP_INDEX_READ_STEP        27
+#define AVA8_OTP_INDEX_ASIC_NUM         28
+#define AVA8_OTP_INDEX_CYCLE_HIT        29
+#define AVA8_OTP_INFO_LOTIDCRC_OFFSET   0
+#define AVA8_OTP_INFO_LOTID_OFFSET      4
+
 struct avalon8_pkg {
 	uint8_t head[2];
 	uint8_t type;

--- a/driver-avalon8.h
+++ b/driver-avalon8.h
@@ -263,7 +263,7 @@ struct avalon8_info {
 	uint32_t total_asics[AVA8_DEFAULT_MODULARS];
 	uint32_t max_ntime; /* Maximum: 7200 */
 
-	uint8_t otp_info[AVA8_DEFAULT_MINER_CNT][AVA8_OTP_LEN + 1];
+	uint8_t otp_info[AVA8_DEFAULT_MODULARS][AVA8_DEFAULT_MINER_CNT][AVA8_OTP_LEN + 1];
 
 	int mod_type[AVA8_DEFAULT_MODULARS];
 	uint8_t miner_count[AVA8_DEFAULT_MODULARS];


### PR DESCRIPTION
together with 3 commits:
1.14c7aeb, the former version of codes didn't consider multiple modules' condition, so fix it;
2. f2146c5, initialize the otp_info related with lotid and waferid to '0'. This is specially useful when cgminer support reading lotid and waferid but MM does't support. Otherwise, the diplaying lotid and waferid info on debug log interface seems incomplete and confusing;
3.37fa353, add reading OTP lotid CRC info. 